### PR TITLE
Code cleanup + added rerender option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,17 @@ RUN pip install PyGithub \
   cffi \
   bumpversion
 
+# Install conda
+RUN wget \
+  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+  && mkdir /root/.conda \
+  && bash Miniconda3-latest-Linux-x86_64.sh -b \
+  && rm -f Miniconda3-latest-Linux-x86_64.sh 
+RUN conda --version
+
+# Install conda-smithy environment
+RUN conda install -n root -c conda-forge conda-smithy
+
 #--target=/app requests PyGithub pygit2 cffi
 
 # A distroless container image with Python and some basics like SSL certificates

--- a/main.py
+++ b/main.py
@@ -3,388 +3,360 @@ import json
 import logging
 import pprint
 from github import Github
-import pygit2
+from github.GithubException import UnknownObjectException
 import re
 from util import *
 import bumpversion.cli
 from datetime import datetime, timedelta
-
-LOGGER = logging.getLogger(__name__)
-
-# set logging level to all
-logging.basicConfig(level=logging.INFO)
-# LOGGER.setLevel(logging.INFO)
-
-BASE_REPO_URL = "https://{token}@github.com/{repository}.git"
-
 import subprocess
 
 
-def main():
-    # two cases
-    # 1. nightly changes detected from hub
-    # 2. standard rerender
-    # 3. push changes and initiate dev release
+# Create logger with logging level set to all
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
+
+def main():
+    # Two events:
+    # 1. Push -> look for tags in commit message and rerender and/or release if found
+    # 2. Nightly -> rerender and release if last changes were more than 24hrs ago
+
+    # Load event data from test dictionary or from GitHub even path environment variable
     if "TEST_DICT" in os.environ:
         event_data = json.loads(os.environ["TEST_DICT"])
     else:
-        with open(os.environ["GITHUB_EVENT_PATH"], 'r') as fp:
+        with open(os.environ["GITHUB_EVENT_PATH"], "r") as fp:
             event_data = json.load(fp)
 
-    # REPOSITORY = event_data["repository"]
-    payload = event_data['client_payload']
+    # Extract payload and event info from event data
+    payload = event_data["client_payload"]
+    event_type = payload["event"]
+    event_name = os.environ["GITHUB_EVENT_NAME"].lower()
+    LOGGER.info("github event: %s", event_name)
+    LOGGER.info("github event data:\n%s", pprint.pformat(event_data))
+    
+    # Quit if the event is not a repository dispatch
+    if event_name != "repository_dispatch":
+        return
 
-    event_type = payload['event']
-    event_name = os.environ['GITHUB_EVENT_NAME'].lower()
+    # Quit if the ref type is not a branch
+    if payload["ref_type"] != "branch":
+        LOGGER.info(
+            "repository_dispatch event: only branch ref type supported right now (was '%s')" % payload["ref_type"]
+        )
+        return
 
-    LOGGER.info('github event: %s', event_name)
-    LOGGER.info('github event data:\n%s', pprint.pformat(event_data))
+    # Start GitHub client
+    gh = Github(os.environ['GH_TOKEN'])
 
-    if event_name == 'repository_dispatch':
+    # Get repository
+    branch_name = payload["ref_name"]
+    s_repository = payload["repository"]
+    s_repository_feedstock = payload["repository"] + "-feedstock"
+    project_repo = gh.get_repo(s_repository)
 
-        gh = Github(os.environ['GH_TOKEN'])
-        branch_name = payload['ref_name']
-
-        s_repository = payload['repository']
-        s_repository_feedstock = payload['repository'] + "-feedstock"
-        repo = gh.get_repo(s_repository)
+    # Get feedstock repository
+    try:
         feedstock_repo = gh.get_repo(s_repository_feedstock)
+    # If feedstock repo does not exist, log an error and exit
+    except UnknownObjectException:
+        LOGGER.error(
+            "repository_dispatch event: feedstock repository of '%s' not found" % s_repository)
+        return
 
-        # check if repo exists
-        if not repository_exists(gh, s_repository_feedstock):
-            LOGGER.error(
-                'repository_dispatch event: feedstock repository not found')
+    # If the even is a push, analyze it to search for [CI] tag
+    if event_type == "push":
+        # Get commit from its sha
+        sha = payload["sha"]
+        commit = project_repo.get_commit(sha=sha)
+        message = commit.raw_data["commit"]["message"]
+
+        # Extract commit tag if there is one
+        tag = re.search(r'\[(.*?)\]', message)
+        supported_tags = ["ci", "rerender"]
+        if tag:
+            tag = tag.group(1)
+            LOGGER.info("tag: %s", tag)
+
+            if tag.lower() in supported_tags:
+                # Remove tag from message, and add it in front
+                commit_message = message.replace(f'[{tag}]', "")
+                # Clean excess spaces
+                commit_message = re.sub(r'\s+', " ", commit_message).strip()
+                # Add tag in front of commit message
+                commit_message = "%s: %s" % (tag.upper(), commit_message)
+
+                # Depending on the tag, trigger rerender only or run continuous integration
+                rerender = tag.lower() == "rerender"
+                release = tag.lower() == "ci"
+
+                # TODO: make rerender and release two functions. For rerender, have option to push immediately, or at the same time as release
+            else:
+                # Quit if the tag is not in the list of supported ones
+                LOGGER.info(
+                    "no supported tag detected (was '%s', supported are %s" % (tag, supported_tags)
+                )
+                return
+        else:
+            # Quit if there is not tag
+            LOGGER.info("no tag detected")
             return
 
-        if payload["ref_type"] != "branch":
+    # If the even is a nightly, rerender, check if there was changes in the last 24hrs and if so, release
+    elif event_type == "nightly":
+        # Trigger rerender
+        rerender = True
+        # Get info of latest commit
+        branch = project_repo.get_branch(branch_name)
+        date_string = branch.commit.raw_data["commit"]["author"]["date"]
+        sha = branch.commit.raw_data["sha"]
+        last_commit_time = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ")
+        
+        # Trigger release if last commit time was less than 22hrs ago
+        if last_commit_time > datetime.now() - timedelta(hours=22):
             LOGGER.info(
-                'repository_dispatch event: only branch ref type supported right now'
+                "since is within 24 hrs, nightly release will follow")
+            release = True
+            commit_message = "BOT: Changes detected in project, nightly release 🌃"
+        else:
+            return
+
+    # Quit if the event is not a push nor a nightly
+    else:
+        return
+
+    # Rerender the feedstock
+    if rerender:
+        # right now we don't rerender here (。_。) !!!!!
+        # see https://github.com/tudat-team/.github/actions/workflows/autorerender.yml
+        # LOGGER.info('cloning feedstock repository')
+        # feedstock_repo, _ = clone_repo(
+        #     repo_feedstock.clone_url,
+        #     FEEDSTOCK_DIR,
+        #     target_branch,
+        #     os.environ['GH_TOKEN'])
+        #
+        # subprocess.run(["git", "checkout", target_branch], cwd=dir)
+        pass
+
+    # Release a conda package
+    if release:
+        # Create path for feedstock and project repos locally
+        FEEDSTOCK_DIR, PROJECT_DIR = [os.path.join(os.environ["GITHUB_WORKSPACE"], name) for name in ["feedstock", "project"]]
+
+        # Clone the feedstock and project repos
+        LOGGER.info("cloning feedstock repository")
+        clone_repo(feedstock_repo.clone_url, FEEDSTOCK_DIR, branch_name, os.environ['GH_TOKEN'])
+        LOGGER.info('cloning project repository')
+        clone_repo(project_repo.clone_url, PROJECT_DIR, branch_name, os.environ['GH_TOKEN'])
+
+        # Checkout correct repo branch
+        for dir in [FEEDSTOCK_DIR, PROJECT_DIR]:
+            subprocess.run(["git", "checkout", branch_name], cwd=dir)
+
+        # Get version from version file in project repo
+        with open(os.path.join(PROJECT_DIR, "version"), 'r') as fp:
+            version = fp.read().rstrip("\n")
+
+        # Declare regex to get last version {% set version = "@VERSION@" %}
+        VERSION_REGEX = re.compile(r'{%\s*set\s*version\s*=\s*"([^"]*)"\s*%}')
+        BUILD_REGEX = re.compile(r'{%\s*set\s*build\s*=\s*"([^"]*)"\s*%}')
+        GIT_REV_REGEX = re.compile(r'{%\s*set\s*git_rev\s*=\s*"([^"]*)"\s*%}')
+        VERSION_PEP440 = re.compile(r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?')
+        TARGETS_REGEX = re.compile(r"-\s+\[(?P<channel>[\w,-].+)\, \s+(?P<subchannel>[\w,-]+)]")
+        TARGETS2_REGEX = re.compile(r"(?<=channel_targets:\n\s\s)-\s+(?P<targets>[\s,\w,-]+)")
+
+        # Match version from file to pep440 and retrieve groups
+        match = VERSION_PEP440.match(version)
+        if match:
+            major = match.group("major")
+            minor = match.group("minor")
+            patch = match.group("patch")
+            release = match.group("release")
+            dev = match.group("dev")
+            if release:
+                version = f"{major}.{minor}.{patch}.{release}{dev}"
+            else:
+                version = f"{major}.{minor}.{patch}"
+            LOGGER.info("version: %s", version)
+            LOGGER.info("major: %s", major)
+            LOGGER.info("minor: %s", minor)
+            LOGGER.info("patch: %s", patch)
+            LOGGER.info("release: %s", release)
+            LOGGER.info("dev: %s", dev)
+        else:
+            LOGGER.error(
+                "repository_dispatch event: could not parse version")
+            return
+
+        # Retrieve version, build, and rev values from previous feedstock metadata
+        VAR_RETRIEVE = [
+            ("version", "recipe/meta.yaml", VERSION_REGEX),
+            ("build", "recipe/meta.yaml", BUILD_REGEX),
+            ("git_rev", "recipe/meta.yaml", GIT_REV_REGEX),
+        ]
+        old_var_vals = get_var_values(VAR_RETRIEVE, FEEDSTOCK_DIR)
+        LOGGER.info("old_var_vals: %s", pprint.pformat(old_var_vals))
+        LOGGER.info("version: %s", version)
+        # Make sure the version is the same as the one in the feedstock
+        assert old_var_vals["version"] == version, "version mismatch"
+
+        # Trigger release if branch is develop, or if the environment is test
+        if branch_name == "develop" or "TEST_DICT" in os.environ:
+
+            if release == "dev":
+                # If the version is in dev, bump the dev version number
+                LOGGER.info(
+                    "repository_dispatch event: bumping dev version")
+                bump_command = ["dev", "--tag"]
+            else:
+                # Otherwise, bump the patch version number
+                LOGGER.info(
+                    "repository_dispatch event: bumping patch version")
+                bump_command = ["patch", "--tag"]
+        else:
+            LOGGER.info(
+                "repository_dispatch event: only dev branch is supported for release"
             )
             return
 
-        if event_type == "push":
-            sha = payload['sha']
-            commit = repo.get_commit(sha=sha)
-            message = commit.raw_data['commit']['message']
-            tag = re.search(r'\[(.*?)\]', message)
-            if tag:
-                tag = tag.group(1)
+        # Set credentials
+        user = "Delfi-C3"
+        email = "Delfi-C3@users.noreply.github.com"
+        # Specify in username if the commit results from a test
+        if "TEST_DICT" in os.environ:
+            user = "Delfi-C3-TEST"
+            email = "Delfi-C3-TEST@users.noreply.github.com"
+        subprocess.run(["git", "config", "--global", "user.name", user])
+        subprocess.run(["git", "config", "--global", "user.email", email])
 
-                # remove match from message
-                commit_message = message.replace(f'[{tag}]', '')
-                commit_message = "CI: " + commit_message
+        # Get current working directory
+        cwd = os.getcwd()
+        # Bump project version
+        os.chdir(PROJECT_DIR)
+        bumpversion.cli.main(bump_command)
+        os.chdir(cwd)
+        LOGGER.info("bumping version with command: %s", bump_command)
 
-                LOGGER.info('tag: %s', tag)
-                if not tag.lower() == 'ci':
-                    LOGGER.info('no ci tag detected')
-                    return  # will stop main() entirely
-                else:
-                    rerender = True
-                    release = True
-            else:
-                LOGGER.info('no ci tag detected')
-                return  # will stop main() entirely
+        # Get new version from version file in project repo open file
+        with open(os.path.join(PROJECT_DIR, "version"), "r") as fp:
+            new_version = fp.read().rstrip("\n")
 
-        # rerender
-        elif event_type == "nightly":
-            rerender = True
-            # time 24 hours ago
-            branch = repo.get_branch(branch_name)
-            date_string = branch.commit.raw_data['commit']['author']['date']
-            sha = branch.commit.raw_data['sha']
-            since = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ")
-            # check if since is within 24 hrs
-            if since > datetime.now() - timedelta(hours=22):
-                LOGGER.info(
-                    'since is within 24 hrs, nightly release will follow')
-                release = True
-                commit_message = "BOT: Changes detected in project, nightly release 🌃 "
-            else:
-                return  # will stop main() entirely
+        # Update version number in feedstock metadata
+        new_var_vals = update_var_values(old_var_vals, new_version)
+        VAR_SUBSTITUTE = [
+            # These note where/how to find the version numbers
+            ("recipe/meta.yaml", VERSION_REGEX, r'{% set version = "{}" %}', new_var_vals["version"]),
+            ("recipe/meta.yaml", BUILD_REGEX, r'{% set build = "{}" %}', new_var_vals["build"]),
+            ("recipe/meta.yaml", GIT_REV_REGEX, r'{% set git_rev = "v{}" %}', new_var_vals["git_rev"]),
+            # Make sure that dev branch is used in conda configs
+            # ("recipe/conda_build_config.yaml", TARGETS2_REGEX, r"- tudat-team {}", remap(branch_name)),
+            # ("conda-forge.yml", TARGETS_REGEX, r'- [tudat-team, {}]', remap(branch_name))
+        ]
+        # Substitute all vars accordingly
+        for file, regex, subst, val in VAR_SUBSTITUTE:
+            path = os.path.join(FEEDSTOCK_DIR, file)
+            # Read file
+            with open(path, "r") as f:
+                s = f.read()
+                # Substitute
+                s = regex.sub(subst.replace("{}", str(val)), s)
+            # Write file    
+            with open(path, "w") as f:
+                f.write(s)
 
-        else:
-            return  # (right now this is these are the only two events)
+        # Push changes to GitHub
+        for repo, dir in [(s_repository_feedstock, FEEDSTOCK_DIR),
+                            (s_repository, PROJECT_DIR)]:
+            # Add all files
+            subprocess.run(["git", "add", "."], cwd=dir)
 
-        if rerender:
-            # right now we don't rerender here :( !!!!!
-            # see https://github.com/tudat-team/.github/actions/workflows/autorerender.yml
-            # LOGGER.info('cloning feedstock repository')
-            # feedstock_repo, _ = clone_repo(
-            #     repo_feedstock.clone_url,
-            #     FEEDSTOCK_DIR,
-            #     target_branch,
-            #     os.environ['GH_TOKEN'])
-            #
-            # subprocess.run(["git", "checkout", target_branch], cwd=dir)
-            pass
+            # Commit with proper commit message
+            subprocess.run(["git", "commit", "-m", commit_message], cwd=dir)
 
-        if release:
-            FEEDSTOCK_DIR = os.path.join(
-                os.environ['GITHUB_WORKSPACE'],
-                "feedstock")
+            # Get url to push to
+            repo_auth_url = "https://%s@github.com/%s.git" % (os.environ["GH_TOKEN"], repo)
 
-            PROJECT_DIR = os.path.join(
-                os.environ['GITHUB_WORKSPACE'],
-                "project")
+            # Push changes and tags
+            subprocess.run(["git", "push", "--all", "-f", repo_auth_url], cwd=dir)
+            subprocess.run(["git", "push", repo_auth_url, branch_name, "--tags"], cwd=dir)
 
-            LOGGER.info('cloning feedstock repository')
-            feedstock_repo, _ = clone_repo(
-                feedstock_repo.clone_url,
-                FEEDSTOCK_DIR,
-                branch_name,
-                os.environ['GH_TOKEN'])
-
-            LOGGER.info('cloning project repository')
-            project_repo, _ = clone_repo(
-                repo.clone_url,
-                PROJECT_DIR,
-                branch_name,
-                os.environ['GH_TOKEN'])
-
-            for repo, dir in [(s_repository_feedstock, FEEDSTOCK_DIR),
-                              (s_repository, PROJECT_DIR)]:
-                subprocess.run(["git", "checkout", branch_name], cwd=dir)
-
-            # get version from version file in project repo open file
-            with open(os.path.join(PROJECT_DIR, "version"), 'r') as fp:
-                version = fp.read().rstrip("\n")
-
-            # use regex to get last version {% set version = "@VERSION@" %}
-            VERSION_REGEX = re.compile(
-                r'{%\s*set\s*version\s*=\s*"([^"]*)"\s*%}')
-            BUILD_REGEX = re.compile(r'{%\s*set\s*build\s*=\s*"([^"]*)"\s*%}')
-            GIT_REV_REGEX = re.compile(
-                r'{%\s*set\s*git_rev\s*=\s*"([^"]*)"\s*%}')
-            VERSION_PEP440 = re.compile(
-                r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<dev>\d+))?')
-            TARGETS_REGEX = re.compile(
-                r"-\s+\[(?P<channel>[\w,-].+)\, \s+(?P<subchannel>[\w,-]+)]")
-            TARGETS2_REGEX = re.compile(
-                r"(?<=channel_targets:\n\s\s)-\s+(?P<targets>[\s,\w,-]+)")
-
-            # match to pep440 and retrieve groups
-            match = VERSION_PEP440.match(version)
-            if match:
-                major = match.group('major')
-                minor = match.group('minor')
-                patch = match.group('patch')
-                release = match.group('release')
-                dev = match.group('dev')
-                if release:
-                    version = f"{major}.{minor}.{patch}.{release}{dev}"
-                else:
-                    version = f"{major}.{minor}.{patch}"
-                LOGGER.info('version: %s', version)
-                LOGGER.info('major: %s', major)
-                LOGGER.info('minor: %s', minor)
-                LOGGER.info('patch: %s', patch)
-                LOGGER.info('release: %s', release)
-                LOGGER.info('dev: %s', dev)
-            else:
-                LOGGER.error(
-                    'repository_dispatch event: could not parse version')
-                return
-
-            # retrieve values from previous feedstock metadata
-            VAR_RETRIEVE = [
-                ('version', 'recipe/meta.yaml', VERSION_REGEX),
-                ('build', 'recipe/meta.yaml', BUILD_REGEX),
-                ('git_rev', 'recipe/meta.yaml', GIT_REV_REGEX),
-            ]
-
-            old_var_vals = get_var_values(VAR_RETRIEVE, FEEDSTOCK_DIR)
-            LOGGER.info('old_var_vals: %s', pprint.pformat(old_var_vals))
-            LOGGER.info('version: %s', version)
-            assert old_var_vals['version'] == version, "version mismatch"
-
-            if branch_name == "develop":
-                # print match information
-                if release == "dev":
-                    LOGGER.info(
-                        'repository_dispatch event: bumping dev version')
-                    # we bump the n of the dev release
-                    bump_command = [
-                        'dev', '--tag']  # '--config-file', PROJECT_DIR + '/.bumpversion.cfg']
-                else:
-                    # we just increase patch, which will automatically start
-                    # a dev release at the same time
-                    LOGGER.info(
-                        'repository_dispatch event: bumping patch version')
-                    bump_command = [
-                        'patch', '--tag']  # '--config-file', PROJECT_DIR + '/.bumpversion.cfg']
-            else:
-                LOGGER.info(
-                    'repository_dispatch event: only branch ref type supported'
-                )
-                return
-
-            # set credentials
-            user = "Delfi-C3"
-            email = "Delfi-C3@users.noreply.github.com"
-            subprocess.run(["git", "config", "--global", "user.name", user])
-            subprocess.run(["git", "config", "--global", "user.email", email])
-
-            # get current working directory
-            cwd = os.getcwd()
-
-            os.chdir(PROJECT_DIR)
-            bumpversion.cli.main(bump_command)
-            os.chdir(cwd)
-            # bump version
-            # print(bump_command)
-            LOGGER.info('bumping version with command: %s', bump_command)
-
-            # os.system(' '.join(bump_command))
-            # subprocess.run(bump_command, cwd=PROJECT_DIR)
-            # get version from version file in project repo open file
-            with open(os.path.join(PROJECT_DIR, "version"), 'r') as fp:
-                new_version = fp.read().rstrip("\n")
-
-            new_var_vals = update_var_values(old_var_vals, new_version,
-                                             new_version)
-                                             # payload['sha'])
-
-            VAR_SUBSTITUTE = [
-                # These note where/how to find the version numbers
-                ('recipe/meta.yaml', VERSION_REGEX, r'{% set version = "{}" %}',
-                 new_var_vals['version']),
-                ('recipe/meta.yaml', BUILD_REGEX, r'{% set build = "{}" %}',
-                 new_var_vals['build']),
-                ('recipe/meta.yaml', GIT_REV_REGEX, r'{% set git_rev = "v{}" %}',
-                 new_var_vals['git_rev']),
-                # ('recipe/conda_build_config.yaml', TARGETS2_REGEX,
-                #  r'- tudat-team {}',
-                #  remap(branch_name)),
-                ('conda-forge.yml', TARGETS_REGEX, r'- [tudat-team, {}]',
-                 remap(branch_name)),
-            ]
-
-            # substitute all vars accordingly
-            for file, regex, subst, val in VAR_SUBSTITUTE:
-                path = os.path.join(FEEDSTOCK_DIR, file)
-                with open(path, 'r') as f:
-                    s = f.read()
-                    s = regex.sub(subst.replace("{}", str(val)), s)
-                with open(path, 'w') as f:
-                    f.write(s)
-
-            # set credentials
-            user = "Delfi-C3"
-            email = "Delfi-C3@users.noreply.github.com"
-            subprocess.run(["git", "config", "--global", "user.name", user])
-            subprocess.run(["git", "config", "--global", "user.email", email])
-
-            # checkout develop branch with subprocess
-            for repo, dir in [(s_repository_feedstock, FEEDSTOCK_DIR),
-                              (s_repository, PROJECT_DIR)]:
-                # subprocess.run(["git", "checkout", "develop"], cwd=dir)
-
-                # add all files
-                subprocess.run(["git", "add", "."], cwd=dir)
-
-                # use subprocess to commit, set cwd to target_repo
-                subprocess.run(["git", "commit", "-m", commit_message],
-                               cwd=dir)
-
-                # # use subprocess to push
-                repo_auth_url = BASE_REPO_URL.format(
-                    token=os.environ["GH_TOKEN"],
-                    repository=repo)
-
-                subprocess.run(
-                    ["git", "push", "--all", "-f", repo_auth_url], cwd=dir)
-
-                subprocess.run(
-                    ["git", "push", repo_auth_url, branch_name, "--tags"], cwd=dir)
 def remap(key):
     map = {
         "develop": "dev",
-        "master": "main",
-        "main": "main",
+        "master": "main"
     }
     if key in map:
         return map[key]
     return key
 
-
-import shutil
-
 if __name__ == "__main__":
-    main()
-    # gh = Github('')
-    # repo = gh.get_repo('tudat-team/tudat-resources')
-    # target_branch = "develop"
-    # #
-    # # sha = '0952fd3f3d2a8350bb18f27a6a32351b45082336'
-    # # commit = repo.get_commit(sha=sha)
-    # # print(commit.raw_data['commit']['message'])
-    #
-    # # since = datetime.now() - timedelta(days=3)
-    #
-    # branch = repo.get_branch(target_branch)
-    # date_string = branch.commit.raw_data['commit']['author']['date']
-    # # convert to datetime
-    # since = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ")
-    #
-    # # check if since is within 24 hrs
-    # if since > datetime.now() - timedelta(hours=24):
-    #
-    # print(branch)
-    # print(branch.commit.raw_data['commit']['author']['date'])
-    # print(branch.commit.raw_data)
-    # print(branch.last_modified)
-    # print(branch.commit.sha)
+    # Set to true for testing (emulate repository dispatch event)
+    test_env = True
 
-    # commits = repo.get_commits(since=since, branch='develop')
-    # print(commits)
-    # last = commits[0]
+    if not test_env:
+        main()
+    else:
+        import shutil
+        # Use export GH_TOKEN=<your token> to test with your own token.
+        # Aslo see https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
+        if "GH_TOKEN" not in os.environ:
+            raise ValueError("GH_TOKEN not set")
 
-    # try:
-    #     os.environ["GH_TOKEN"] = ""
-    #     os.environ["GITHUB_WORKSPACE"] = "./tmp"
-    #     os.environ["TEST_DICT"] = json.dumps(dict(
-    #         client_payload=dict(
-    #             ref_name="develop",
-    #             repository="tudat-team/tudat-resources",
-    #             sha="0952fd3f3d2a8350bb18f27a6a32351b45082336",
-    #             ref="refs/heads/develop",
-    #             ref_type="branch",
-    #             actor="geoffreygarrett",
-    #             event="push")
-    #     ))
-    #
-    #     os.environ["GITHUB_EVENT_NAME"] = "repository_dispatch"
-    #     main()
-    #     shutil.rmtree(os.environ['GITHUB_WORKSPACE'])
-    #
-    # except ValueError as e:
-    #     print(e)
-    #     shutil.rmtree(os.environ['GITHUB_WORKSPACE'])
+        gh = Github(os.environ["GH_TOKEN"])
+        target_repo = "tudat-team/tudatpy"
+        target_branch = "test_automation"
+        
+        # Get last commit from given branch
+        repo = gh.get_repo(target_repo)
+        branch = repo.get_branch(target_branch)
+        # Convert commit time to datetime
+        since = datetime.strptime(branch.commit.raw_data["commit"]["author"]["date"], "%Y-%m-%dT%H:%M:%SZ")
+        # Check if the commit was less than 24hrs ago
+        less_than_24_hrs = since < datetime.now() - timedelta(hours=24)
+        
+        # Print last commit infos
+        print("Last commit was on branch '%s' by '%s' on %s (%s than 24hrs ago)" % (
+            branch.name,
+            branch.commit.raw_data["commit"]["author"]["name"],
+            since,
+            "more" if less_than_24_hrs else "less")
+        )
+        print("Commit message: %s" % branch.commit.raw_data["commit"]["message"])
+        print("Commit url: https://github.com/%s/commit/%s" % (repo.full_name, branch.commit.sha))
+        print()
 
-    # token = ''
-    # github = Github(token)
-    # g = Github(token)
+        try:
+            # Set environment variables to test automation on last commit
+            os.environ["GITHUB_WORKSPACE"] = "./tmp"
+            os.environ["TEST_DICT"] = json.dumps(dict(
+                client_payload=dict(
+                    ref_name=target_branch,
+                    repository=target_repo,
+                    sha=branch.commit.sha,
+                    ref="refs/heads/%s"%target_branch,
+                    ref_type="branch",
+                    actor=branch.commit.raw_data["commit"]["author"]["name"],
+                    event="push")
+            ))
+            os.environ["GITHUB_EVENT_NAME"] = "repository_dispatch"
 
-    # if repository_exists(g, 'tudat-team/tudat-resources'):
-    #     print("yes")
-    # repo = github.get_repo('tudat-team/tudat-resources-feedstock')
-    # project_repo = github.get_repo('tudat-team/tudat-resources')
-    # fil = project_repo.get_contents("version")
-    # # print(fil.content)
-    #
-    # # repo = g.get_repo("PyGithub/PyGithub")
-    #
-    # branch = "develop"
-    # contents = project_repo.get_contents("version", ref=branch)
-    # version = contents.decoded_content.decode("ascii")
+            # Print environment variables
+            print("The following environment variables are set:")
+            print(" * GITHUB_WORKSPACE: %s" % os.environ["GITHUB_WORKSPACE"])
+            print(" * TEST_DICT: %s" % os.environ["TEST_DICT"])
+            print(" * GITHUB_EVENT_NAME: %s" % os.environ["GITHUB_EVENT_NAME"])
+            print()
 
-    # cloned_repo = clone_repo(repo..git_url, './tmp/feedstock', branch, token)
+            # Run automation
+            main()
 
-    # vars = {
-    #     "REPOSITORY": "tudat-team/tudat-resources-feedstock",
-    #
-    #     "SUBCHANNEL": branch_channel_map(branch)
-    # }
-
-    # main()
+            # Cleanup
+            try:
+                shutil.rmtree(os.environ["GITHUB_WORKSPACE"])
+            except FileNotFoundError:
+                pass
+        
+        except ValueError as e:
+            print(e)
+            shutil.rmtree(os.environ["GITHUB_WORKSPACE"])

--- a/main.py
+++ b/main.py
@@ -71,7 +71,7 @@ def main():
         # Trigger rerender
         rerender = True
         # If last commit was less than 22hrs ago, trigger release
-        release = was_last_branch_commit_recent(project_repo, branch_name, time_treshold=timedelta(hours=22))
+        release = was_branch_last_commit_recent(project_repo, branch_name, time_treshold=timedelta(hours=22))
 
     # Quit if the event is not a push nor a nightly
     else:

--- a/main.py
+++ b/main.py
@@ -17,8 +17,8 @@ logging.basicConfig(level=logging.INFO)
 
 def main():
     # Two events:
-    # 1. Push -> look for tags in commit message and rerender and/or release if found
-    # 2. Nightly -> rerender and release if last changes were more than 24hrs ago
+    # 1. Push to tudat/tudatpy -> look for [CI]/[Rerender] tags in commit message and rerender and/or release if found
+    # 2. Nightly -> rerender and release if last changes were less than 24hrs ago
 
     # Load event data from test dictionary or from GitHub even path environment variable
     if "TEST_DICT" in os.environ:

--- a/util.py
+++ b/util.py
@@ -262,7 +262,6 @@ def get_var_values(var_retrieve, root=''):
             ret[var] = v
     return ret
 
-
 def update_var_values(var_retrieved, version_tag, git_rev=None, root=''):
     ret = {}
     git_rev = version_tag if git_rev is None else git_rev
@@ -279,3 +278,16 @@ def update_var_values(var_retrieved, version_tag, git_rev=None, root=''):
             v = version_tag
         ret[k] = v
     return ret
+
+def substitute_vars_in_file(vars_substitute, directory):
+    # Substitute variables in files
+    for file, regex, subst, val in vars_substitute:
+        path = os.path.join(directory, file)
+        # Read file
+        with open(path, "r") as f:
+            s = f.read()
+            # Substitute
+            s = regex.sub(subst.replace("{}", str(val)), s)
+        # Write file    
+        with open(path, "w") as f:
+            f.write(s)

--- a/util.py
+++ b/util.py
@@ -1,12 +1,9 @@
-import time
 import os
 import requests
 import urllib3.util.retry
 import pygit2
 from github import Github
-import enum
-import re
-import os
+
 
 def create_api_sessions(github_token):
     """Create API sessions for GitHub.
@@ -88,8 +85,9 @@ def get_var_values(var_retrieve, root=''):
     return ret
 
 
-def update_var_values(var_retrieved, version_tag, git_rev, root=''):
+def update_var_values(var_retrieved, version_tag, git_rev=None, root=''):
     ret = {}
+    git_rev = version_tag if git_rev is None else git_rev
     for k, v in var_retrieved.items():
         if k == 'build':
             if var_retrieved['version'] == version_tag:
@@ -105,12 +103,5 @@ def update_var_values(var_retrieved, version_tag, git_rev, root=''):
     return ret
 
 
-from github.GithubException import UnknownObjectException
-
-
-def repository_exists(github_client, repository):
-    try:
-        github_client.get_repo(repository)
-    except UnknownObjectException:
-        return False
-    return True
+# TODO
+# Remove repository_exists, replace by load_repository(github_client, repo_name) and throw/log error if not exists

--- a/util.py
+++ b/util.py
@@ -94,7 +94,7 @@ def get_commit_tags(repo, commit_hash, supported_tags=["ci", "rerender"]):
         LOGGER.info("no tag detected")
         return {possible_tag: False for possible_tag in supported_tags}, None
 
-def was_last_branch_commit_recent(repo, branch_name, time_treshold=timedelta(hours=24)):
+def was_branch_last_commit_recent(repo, branch_name, time_treshold=timedelta(hours=24)):
     """
     Check if the last commit of a branch is recent.
     Parameters


### PR DESCRIPTION
Through this `code_cleanup` branch, I have cleaned up the `main.py` code by moving part of it as utils, and editing pieces of code where I thought improvements could be made.

I have also added the option to rerender (as part of CI, or just by itself).

I am not 100% certain that the changes I made to the `Dockerfile` will work, but I can only test that by running non-locally, for which I thus need to merge this new branch to main.

@geoffreygarrett can you have a look at this pull request, so that I can merge it, and test that everything works once fully integrated with the GitHub actions from the tudat/tudatpy(-feedstock) repos? If things don't work, I can always revert the merge, as I won't immediately delete this `code_cleanup` branch.